### PR TITLE
Add required field `.paths` in ZON file for Zig v0.12.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,4 +1,8 @@
 .{
     .name = "chameleon",
+    .minimum_zig_version = "0.12.0",
     .version = "0.1.0",
+    .paths = .{
+        "",
+    },
 }


### PR DESCRIPTION
Zig v0.12.0 seems to have introduced breaking changes to ZON file's required fields. It needs `.paths` field.
`""` value means this package includes all files in the source tree.
Additionally, I added `.minimum_zig_version` to indicate the ZON file is tested on v0.12.0.

(FYI, v0.11.0 cannot build this package due to the breaking changes of `addModule`'s argument. )

