### PR TITLE
use an inline function to reduce code duplication when getting styles in chameleon.zig

### DIFF
--- a/src/chameleon.zig
+++ b/src/chameleon.zig
@@ -1,4 +1,3 @@
-const Styles = @import("styles.zig").Styles;
 const Utils = @import("utils.zig");
 
 const InitColorLevel = enum { Disabled, BasicColor, Color256, TrueColor, Auto };
@@ -17,83 +16,35 @@ pub const Chameleon = struct {
     }
 
     pub inline fn reset(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn bold(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn dim(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn italic(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn underline(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn overline(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn inverse(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn hidden(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn visible(self: Chameleon) Chameleon {
@@ -106,373 +57,151 @@ pub const Chameleon = struct {
     }
 
     pub inline fn strikethrough(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn black(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn red(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn green(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn yellow(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn blue(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn magenta(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn cyan(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn white(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn blackBright(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn gray(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn grey(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn redBright(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn greenBright(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn yellowBright(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn blueBright(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn magentaBright(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn cyanBright(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn whiteBright(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn bgBlack(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn bgRed(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn bgGreen(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn bgYellow(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn bgBlue(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn bgMagenta(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn bgCyan(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn bgWhite(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn bgBlackBright(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn bgGray(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn bgGrey(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn bgRedBright(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn bgGreenBright(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn bgYellowBright(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn bgBlueBright(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn bgMagentaBright(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn bgCyanBright(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn bgWhiteBright(self: Chameleon) Chameleon {
-        const style = Utils.wrapStyle(@field(Styles, @src().fn_name));
-        comptime return .{
-            .level = self.level,
-            .visible_always = self.visible_always,
-            .open = self.open ++ style[0],
-            .close = self.close ++ style[1],
-        };
+        return Utils.getStyle(self, @src().fn_name);
     }
 
     pub inline fn rgb(self: Chameleon, r: u8, g: u8, b: u8) Chameleon {

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1,4 +1,6 @@
 const fmt = @import("std").fmt;
+const Chameleon = @import("chameleon.zig").Chameleon;
+const Styles = @import("styles.zig").Styles;
 
 pub inline fn wrapStyle(style: [2][]const u8) [2][]const u8 {
     return [_][]const u8{ "\u{001B}[" ++ style[0] ++ "m", "\u{001B}[" ++ style[1] ++ "m" };
@@ -19,5 +21,15 @@ pub fn rgbFromHex(comptime hex: []const u8) [3]u32 {
         (hexInt >> 16) & 0xFF,
         (hexInt >> 8) & 0xFF,
         hexInt & 0xFF,
+    };
+}
+
+pub inline fn getStyle(cham: Chameleon, style_name: []const u8) Chameleon {
+    const style = wrapStyle(@field(Styles, style_name));
+    comptime return .{
+        .level = cham.level,
+        .visible_always = cham.visible_always,
+        .open = cham.open ++ style[0],
+        .close = cham.close ++ style[1],
     };
 }


### PR DESCRIPTION
this pr replaces the repeated calls to 
```zig
const style = wrapStyle(@field(Styles, @src().fn_name));
comptime return .{
    .level = self.level,
    .visible_always = self.visible_always,
    .open = self.open ++ style[0],
    .close = self.close ++ style[1],
};
```
with the function
```zig
Utils.getStyle(self, @src().fn_name);
```
to reduce a lot of code duplication when getting the styles from styles.zig

