### PR TITLE
Make addStyle() & Chameleon types public

### DIFF
--- a/src/api/Comptime.zig
+++ b/src/api/Comptime.zig
@@ -25,7 +25,7 @@ pub inline fn printErr(self: *Chameleon, comptime format: []const u8, args: anyt
     try std.io.getStdErr().writer().print(self.fmt(format), args);
 }
 
-inline fn addStyle(self: *Chameleon, comptime style_name: []const u8) *Chameleon {
+pub inline fn addStyle(self: *Chameleon, comptime style_name: []const u8) *Chameleon {
     const style = Utils.wrapStyle(@field(Styles, style_name));
     self.open = self.open ++ style[0];
     self.close = style[1] ++ self.close;

--- a/src/api/Runtime.zig
+++ b/src/api/Runtime.zig
@@ -39,7 +39,7 @@ pub fn printErr(self: *Chameleon, comptime format: []const u8, args: anytype) !v
     try writer.writeAll(self.close.items);
 }
 
-fn addStyle(self: *Chameleon, comptime style_name: []const u8) *Chameleon {
+pub fn addStyle(self: *Chameleon, comptime style_name: []const u8) *Chameleon {
     if (!self.no_color) {
         const style = Utils.wrapStyle(@field(Styles, style_name));
         self.open.appendSlice(style[0]) catch {};

--- a/src/chameleon.zig
+++ b/src/chameleon.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
-const ComptimeChameleon = @import("api/Comptime.zig");
-const RuntimeChameleon = @import("api/Runtime.zig");
+pub const ComptimeChameleon = @import("api/Comptime.zig");
+pub const RuntimeChameleon = @import("api/Runtime.zig");
 pub const HexColors = @import("colors.zig");
 
 pub fn initComptime() ComptimeChameleon {


### PR DESCRIPTION
- Make addStyle function public to allow for better meta programming. 
- Make Chameleon types public to enable better type safety.