### PR TITLE
feat: add `print` API

### DIFF
--- a/src/api/Comptime.zig
+++ b/src/api/Comptime.zig
@@ -13,16 +13,20 @@ pub inline fn fmt(self: *Chameleon, comptime text: []const u8) []const u8 {
     return self.open ++ text ++ self.close;
 }
 
+/// Print the formatted text to a `File` writer.
+pub inline fn print(self: *Chameleon, writer: std.fs.File.Writer, comptime text: []const u8, args: anytype) !void {
+    defer self.removeAll();
+    try writer.print(self.fmt(text), args);
+}
+
 /// Print the formatted text to stdout.
 pub inline fn printOut(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
-    defer self.removeAll();
-    try std.io.getStdOut().writer().print(self.fmt(format), args);
+    return self.print(std.io.getStdOut().writer(), format, args);
 }
 
 /// Print the formatted text to stderr.
 pub inline fn printErr(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
-    defer self.removeAll();
-    try std.io.getStdErr().writer().print(self.fmt(format), args);
+    return self.print(std.io.getStdErr().writer(), format, args);
 }
 
 pub inline fn addStyle(self: *Chameleon, comptime style_name: []const u8) *Chameleon {

--- a/src/api/Runtime.zig
+++ b/src/api/Runtime.zig
@@ -21,22 +21,22 @@ pub fn fmt(self: *Chameleon, comptime format: []const u8, args: anytype) ![]u8 {
     return if (self.no_color) formatted else std.mem.concat(self.allocator, u8, &.{ self.open.items, formatted, self.close.items });
 }
 
-/// Print the formatted text to stdout.
-pub fn printOut(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
+/// Print the formatted text to a `File` writer.
+pub fn print(self: *Chameleon, writer: std.fs.File.Writer, comptime format: []const u8, args: anytype) !void {
     defer self.removeAll();
-    const writer = std.io.getStdOut().writer();
     try writer.writeAll(self.open.items);
     try writer.print(format, args);
     try writer.writeAll(self.close.items);
 }
 
+/// Print the formatted text to stdout.
+pub fn printOut(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
+    return self.print(std.io.getStdOut().writer(), format, args);
+}
+
 /// Print the formatted text to stderr.
 pub fn printErr(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
-    defer self.removeAll();
-    const writer = std.io.getStdErr().writer();
-    try writer.writeAll(self.open.items);
-    try writer.print(format, args);
-    try writer.writeAll(self.close.items);
+    return self.print(std.io.getStdErr().writer(), format, args);
 }
 
 pub fn addStyle(self: *Chameleon, comptime style_name: []const u8) *Chameleon {


### PR DESCRIPTION
## What This PR Does

Adds `print` to comptime and runtime APIs. It is identical to `printOut` and `printErr`, but allows for printing to an arbitrary `File.Writer`. I also refactored those methods to consume `print` and de-duplicate code.