### PR TITLE
test: add basic testing setup

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -27,4 +27,10 @@ pub fn build(b: *std.Build) void {
 
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
+
+    const tests = b.addTest(.{ .root_source_file = b.path("src/chameleon.zig") });
+    const run_tests = b.addRunArtifact(tests);
+    run_tests.step.dependOn(&tests.step);
+    const run_tests_step = b.step("test", "Run tests");
+    run_tests_step.dependOn(&run_tests.step);
 }

--- a/src/chameleon.zig
+++ b/src/chameleon.zig
@@ -20,3 +20,7 @@ pub fn initRuntime(config: Config) RuntimeChameleon {
         .no_color = if (!config.detect_no_color) false else std.process.hasEnvVarConstant("NO_COLOR"),
     };
 }
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -24,3 +24,7 @@ pub inline fn rgbFromHex(hex_code: []const u8) [3]u32 {
         hex_int & 0xFF, // blue
     };
 }
+
+test rgbFromHex {
+    try std.testing.expectEqual([_]u32{ 0xFF, 0xAA, 0x00 }, rgbFromHex("FFAA00"));
+}


### PR DESCRIPTION
## What This PR Does
- Adds a `test` step to `build.zig`
- Adds a single unit test for `rgbFromHex`.

This is the first of two PRs. I found a memory leak in the runtime API, but I'm splitting the testing and the fix into separate PRs.