### PR TITLE
Use the new `std.Io.Writer`

### DIFF
--- a/src/api/Comptime.zig
+++ b/src/api/Comptime.zig
@@ -13,20 +13,20 @@ pub inline fn fmt(self: *Chameleon, comptime text: []const u8) []const u8 {
     return self.open ++ text ++ self.close;
 }
 
-/// Print the formatted text to a `File` writer.
-pub inline fn print(self: *Chameleon, writer: std.fs.File.Writer, comptime text: []const u8, args: anytype) !void {
+/// Print the formatted text to an `Io` writer.
+pub inline fn print(self: *Chameleon, writer: std.Io.Writer, comptime text: []const u8, args: anytype) !void {
     defer self.removeAll();
     try writer.print(self.fmt(text), args);
 }
 
 /// Print the formatted text to stdout.
 pub inline fn printOut(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
-    return self.print(std.io.getStdOut().writer(), format, args);
+    return self.print(std.fs.File.stdout().writer(&.{}), format, args);
 }
 
 /// Print the formatted text to stderr.
 pub inline fn printErr(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
-    return self.print(std.io.getStdErr().writer(), format, args);
+    return self.print(std.fs.File.stderr().writer(&.{}), format, args);
 }
 
 pub inline fn addStyle(self: *Chameleon, comptime style_name: []const u8) *Chameleon {

--- a/src/api/Comptime.zig
+++ b/src/api/Comptime.zig
@@ -19,14 +19,21 @@ pub inline fn print(self: *Chameleon, writer: std.Io.Writer, comptime text: []co
     try writer.print(self.fmt(text), args);
 }
 
+/// Print the formatted text to a `File`.
+pub inline fn printToFile(self: *Chameleon, file: std.fs.File, comptime format: []const u8, args: anytype) !void {
+    var buf: [1024]u8 = undefined;
+    var writer = file.writer(&buf);
+    try self.print(&writer.interface, format, args);
+    return writer.interface.flush();
+}
 /// Print the formatted text to stdout.
 pub inline fn printOut(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
-    return self.print(std.fs.File.stdout().writer(&.{}), format, args);
+    return self.printToFile(.stdout(), format, args);
 }
 
 /// Print the formatted text to stderr.
 pub inline fn printErr(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
-    return self.print(std.fs.File.stderr().writer(&.{}), format, args);
+    return self.printToFile(.stderr(), format, args);
 }
 
 pub inline fn addStyle(self: *Chameleon, comptime style_name: []const u8) *Chameleon {

--- a/src/api/Runtime.zig
+++ b/src/api/Runtime.zig
@@ -26,8 +26,8 @@ pub fn fmt(self: *Chameleon, comptime format: []const u8, args: anytype) ![]u8 {
     }
 }
 
-/// Print the formatted text to a `File` writer.
-pub fn print(self: *Chameleon, writer: std.fs.File.Writer, comptime format: []const u8, args: anytype) !void {
+/// Print the formatted text to an `Io` writer.
+pub fn print(self: *Chameleon, writer: std.Io.Writer, comptime format: []const u8, args: anytype) !void {
     defer self.removeAll();
     try writer.writeAll(self.open.items);
     try writer.print(format, args);
@@ -36,12 +36,12 @@ pub fn print(self: *Chameleon, writer: std.fs.File.Writer, comptime format: []co
 
 /// Print the formatted text to stdout.
 pub fn printOut(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
-    return self.print(std.io.getStdOut().writer(), format, args);
+    return self.print(std.fs.File.stdout().writer(&.{}), format, args);
 }
 
 /// Print the formatted text to stderr.
 pub fn printErr(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
-    return self.print(std.io.getStdErr().writer(), format, args);
+    return self.print(std.fs.File.stderr().writer(&.{}), format, args);
 }
 
 pub fn addStyle(self: *Chameleon, comptime style_name: []const u8) *Chameleon {

--- a/src/api/Runtime.zig
+++ b/src/api/Runtime.zig
@@ -34,14 +34,22 @@ pub fn print(self: *Chameleon, writer: std.Io.Writer, comptime format: []const u
     try writer.writeAll(self.close.items);
 }
 
+/// Print the formatted text to a `File`.
+pub inline fn printToFile(self: *Chameleon, file: std.fs.File, comptime format: []const u8, args: anytype) !void {
+    var buf: [1024]u8 = undefined;
+    var writer = file.writer(&buf);
+    try self.print(&writer.interface, format, args);
+    return writer.interface.flush();
+}
+
 /// Print the formatted text to stdout.
 pub fn printOut(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
-    return self.print(std.fs.File.stdout().writer(&.{}), format, args);
+    return self.print(.stdout(), format, args);
 }
 
 /// Print the formatted text to stderr.
 pub fn printErr(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
-    return self.print(std.fs.File.stderr().writer(&.{}), format, args);
+    return self.print(.stderr(), format, args);
 }
 
 pub fn addStyle(self: *Chameleon, comptime style_name: []const u8) *Chameleon {


### PR DESCRIPTION
Removes references to the deprecated `std.io.Writer` from `std.fs.File.Writer`.
There's a [writeup here](https://www.openmymind.net/Zigs-New-Writer/).

[Zig 0.15](https://github.com/ziglang/zig/milestone/28) is soon to be released (although they recently removed the due date of 2025-08-12). I still feel that preparation for this change is valid.