### PR TITLE
Zig 0.16.0

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -9,7 +9,7 @@ const Chameleon = @import("chameleon");
 
 pub fn main(init: std.process.Init) !void {
 	comptime var c = Chameleon.initComptime();
-	try c.green().bold().printOut("Hello, world!", .{});
+	try c.green().bold().printOut(init.io, "Hello, world!", .{});
 }
 ```
 
@@ -92,7 +92,7 @@ Apart from the initialization syntax, the colors and style syntax are almost sim
   Print out the stylized text directly to the standard output.
 
   ```zig
-  try c.green().bold().printOut("Hello, world!", .{});
+  try c.green().bold().printOut(io, "Hello, world!", .{});
   ```
 
 - ### `printErr`
@@ -100,7 +100,7 @@ Apart from the initialization syntax, the colors and style syntax are almost sim
   Print out the stylized text directly to the standard error.
 
   ```zig
-  try c.green().bold().printErr("Error!", .{});
+  try c.green().bold().printErr(io, "Error!", .{});
   ```
 
 - ### `reset`...`overline` (Modifiers)
@@ -108,7 +108,7 @@ Apart from the initialization syntax, the colors and style syntax are almost sim
   These modify the text style in which they are displayed like bold, italics etc.
 
   ```zig
-  try c.bold().italic().printOut("Bold italic!", .{});
+  try c.bold().italic().printOut(io, "Bold italic!", .{});
   ```
 
 - ### `black`...`white` (Foreground colors)
@@ -116,7 +116,7 @@ Apart from the initialization syntax, the colors and style syntax are almost sim
   These modify the foreground color of the text.
 
   ```zig
-  try c.green().printOut("Green color!", .{});
+  try c.green().printOut(io, "Green color!", .{});
   ```
 
 - ### `blackBright`...`whiteBright` (Bright Foreground colors)
@@ -124,7 +124,7 @@ Apart from the initialization syntax, the colors and style syntax are almost sim
   These are brighter versions of the above colors.
 
   ```zig
-  try c.greenBright().printOut("Bright green color!", .{});
+  try c.greenBright().printOut(io, "Bright green color!", .{});
   ```
 
 - ### `bgBlack`...`bgWhite` (Background colors)
@@ -132,7 +132,7 @@ Apart from the initialization syntax, the colors and style syntax are almost sim
   These modify the background color of the text.
 
   ```zig
-  try c.bgGreen().printOut("Green background color!", .{});
+  try c.bgGreen().printOut(io, "Green background color!", .{});
   ```
 
 - ### `bgBlackBright`...`bgWhiteBright` (Bright Background colors)
@@ -140,7 +140,7 @@ Apart from the initialization syntax, the colors and style syntax are almost sim
   These are brighter versions of the above colors.
 
   ```zig
-  try c.bgGreenBright().printOut("Bright green background color!", .{});
+  try c.bgGreenBright().printOut(io, "Bright green background color!", .{});
   ```
 
 - ### `rgb` (Custom foreground color)
@@ -148,7 +148,7 @@ Apart from the initialization syntax, the colors and style syntax are almost sim
   Set the text color to the specified rgb values.
 
   ```zig
-  try c.rgb(123, 45, 67).printOut("Reddish color!", .{});
+  try c.rgb(123, 45, 67).printOut(io, "Reddish color!", .{});
   ```
 
 - ### `bgRgb` (Custom background color)
@@ -156,7 +156,7 @@ Apart from the initialization syntax, the colors and style syntax are almost sim
   Set the background color to the specified rgb values.
 
   ```zig
-  try c.bgRgb(123, 45, 67).printOut("Reddish background color!", .{});
+  try c.bgRgb(123, 45, 67).printOut(io, "Reddish background color!", .{});
   ```
 
 - ### `hex` (Custom foreground color)
@@ -166,7 +166,7 @@ Apart from the initialization syntax, the colors and style syntax are almost sim
   Hex color codes can be provided with or without a `#` prefix and also as [hex triplets](https://en.wikipedia.org/wiki/Web_colors#Shorthand_hexadecimal_form).
 
   ```zig
-  try c.hex("#FFAA00").printOut("Orangish color!", .{});
+  try c.hex("#FFAA00").printOut(io, "Orangish color!", .{});
   // Using hex triplet:
   // try c.hex("FA0").printOut(...)
   ```
@@ -178,7 +178,7 @@ Apart from the initialization syntax, the colors and style syntax are almost sim
   Hex color codes can be provided with or without a `#` prefix and also as [hex triplets](https://en.wikipedia.org/wiki/Web_colors#Shorthand_hexadecimal_form).
 
   ```zig
-  try c.bgHex("#FFAA00").printOut("Orangish background color!", .{});
+  try c.bgHex("#FFAA00").printOut(io, "Orangish background color!", .{});
   // Using hex triplet:
   // try c.bgHex("FA0").printOut(...)
   ```
@@ -196,9 +196,9 @@ Apart from the initialization syntax, the colors and style syntax are almost sim
   var panic = try c.bold().redBright().createPreset();
   var warning = try c.hex("#FFA500").italic().createPreset();
 
-  try panic.printErr("This is a panic!", .{});
+  try panic.printErr(io, "This is a panic!", .{});
   ...
-  try warning.printOut("This is a warning!", .{});
+  try warning.printOut(io, "This is a warning!", .{});
   ```
 
 # HexColors
@@ -211,7 +211,7 @@ This is useful if you are familiar with CSS colors and want to use them without 
 const Chameleon = @import("chameleon");
 const Colors = Chameleon.HexColors;
 ...
-try c.hex(Colors.BLUEVIOLET).printOut("Blue violet color!", .{});
+try c.hex(Colors.BLUEVIOLET).printOut(io, "Blue violet color!", .{});
 ...
-try c.bgHex(Colors.GOLDENROD).printOut("Golden background color!", .{});
+try c.bgHex(Colors.GOLDENROD).printOut(io, "Golden background color!", .{});
 ```

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -7,32 +7,65 @@ The styles are applied to the text during comptime hence they are inlined with t
 ```zig
 const Chameleon = @import("chameleon");
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
 	comptime var c = Chameleon.initComptime();
 	try c.green().bold().printOut("Hello, world!", .{});
 }
 ```
 
-
-
 # Chameleon Runtime API
 
 The runtime API is the recommended way to implement colors in your app, if deploying to end users.
+
+The biggest advantage of using the runtime API over the comptime one is that, it supports `NO_COLOR` environment variable standard which if present, dynamically prevents colors from being added to the output.
+
+- ### `initRuntime`
+
+The disadvantage to _this_ runtime initialization method is that it is fallible due to the creation of an environment map, **there are two other method which provide infallibility**.
 
 ```zig
 const std = @import("std");
 const Chameleon = @import("chameleon");
 
-pub fn main() !void {
-  var c = Chameleon.initRuntime(.{ .allocator = std.heap.your_allocator });
+pub fn main(init: std.process.Init) !void {
+  var c = try Chameleon.initRuntime(.{ .allocator = std.heap.your_allocator });
   defer c.deinit();
+  // `config.detect_no_color` is respected, `initRuntime` will only create an environment map if you enable detection.
   try c.green().bold().printOut("Hello, world!", .{});
 }
 ```
 
-The biggest advantage of using the runtime API over the comptime one is that, it supports `NO_COLOR` environment variable standard which if present, dynamically prevents colors from being added to the output.
+- ### `initRuntimeNoDetect`
 
+Implement your own `NO_COLOR` detection and use `initRuntimeNoDetect`, which will not check the `NO_COLOR` environment variable.
 
+```zig
+const std = @import("std");
+const Chameleon = @import("chameleon");
+
+pub fn main(init: std.process.Init) !void {
+  var c = Chameleon.initRuntimeNoDetect(.{ .allocator = std.heap.your_allocator });
+  defer c.deinit();
+  c.no_color = true; // `config.detect_no_color` is ignored, implement your detection here.
+  try c.green().bold().printOut("Hello, world!", .{});
+}
+```
+
+- ### `initRuntimeFromEnviron`
+
+Provide `initRuntimeFromEnviron` with an environment map, such as the one from `std.process.Init` (`init.environ_map`).
+
+```zig
+const std = @import("std");
+const Chameleon = @import("chameleon");
+
+pub fn main(init: std.process.Init) !void {
+  var c = Chameleon.initRuntimeFromEnviron(.{ .allocator = std.heap.your_allocator }, init.environ_map);
+  defer c.deinit();
+  // `config.detect_no_color` is respected, and reads the `NO_COLOR` variable from `init.environ_map`.
+  try c.green().bold().printOut("Hello, world!", .{});
+}
+```
 
 # Styles API
 
@@ -47,7 +80,7 @@ Apart from the initialization syntax, the colors and style syntax are almost sim
   std.debug.print("Hello, {s}", .{
   	c.bold().red().fmt("world!"),
   });
-  
+
   // Runtime API
   std.debug.print("Hello, {s}", .{
   	try c.bold().red().fmt("world!", .{}),
@@ -141,15 +174,15 @@ Apart from the initialization syntax, the colors and style syntax are almost sim
 - ### `bgHex` (Custom background color)
 
   Set the text color to the specified hex color.
-  
+
   Hex color codes can be provided with or without a `#` prefix and also as [hex triplets](https://en.wikipedia.org/wiki/Web_colors#Shorthand_hexadecimal_form).
-  
+
   ```zig
   try c.bgHex("#FFAA00").printOut("Orangish background color!", .{});
   // Using hex triplet:
   // try c.bgHex("FA0").printOut(...)
   ```
-  
+
 - ### `createPreset`
 
   Create a new instance of Chameleon by saving the current styles as a preset, to be used for defining custom themes.
@@ -158,17 +191,15 @@ Apart from the initialization syntax, the colors and style syntax are almost sim
   // Comptime API
   comptime var panic = c.bold().redBright().createPreset();
   comptime var warning = c.hex("#FFA500").italic().createPreset();
-  
+
   // Runtime API
   var panic = try c.bold().redBright().createPreset();
   var warning = try c.hex("#FFA500").italic().createPreset();
-  
+
   try panic.printErr("This is a panic!", .{});
   ...
   try warning.printOut("This is a warning!", .{});
   ```
-
-
 
 # HexColors
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -31,7 +31,7 @@ pub fn main(init: std.process.Init) !void {
   var c = try Chameleon.initRuntime(.{ .allocator = std.heap.your_allocator });
   defer c.deinit();
   // `config.detect_no_color` is respected, `initRuntime` will only create an environment map if you enable detection.
-  try c.green().bold().printOut("Hello, world!", .{});
+  try c.green().bold().printOut(init.io, "Hello, world!", .{});
 }
 ```
 
@@ -47,7 +47,7 @@ pub fn main(init: std.process.Init) !void {
   var c = Chameleon.initRuntimeNoDetect(.{ .allocator = std.heap.your_allocator });
   defer c.deinit();
   c.no_color = true; // `config.detect_no_color` is ignored, implement your detection here.
-  try c.green().bold().printOut("Hello, world!", .{});
+  try c.green().bold().printOut(init.io, "Hello, world!", .{});
 }
 ```
 
@@ -63,7 +63,7 @@ pub fn main(init: std.process.Init) !void {
   var c = Chameleon.initRuntimeFromEnviron(.{ .allocator = std.heap.your_allocator }, init.environ_map);
   defer c.deinit();
   // `config.detect_no_color` is respected, and reads the `NO_COLOR` variable from `init.environ_map`.
-  try c.green().bold().printOut("Hello, world!", .{});
+  try c.green().bold().printOut(init.io, "Hello, world!", .{});
 }
 ```
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,8 +1,8 @@
 .{
     .name = .chameleon,
-    .version = "2.0.1",
+    .version = "2.0.2",
     .fingerprint = 0x3f13cb6e8d5aec64, // Changing this has security and trust implications.
-    .minimum_zig_version = "0.15.0-dev.1228+6dbcc3bd5",
+    .minimum_zig_version = "0.16.0",
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .chameleon,
-    .version = "2.0.2",
+    .version = "3.0.0",
     .fingerprint = 0x3f13cb6e8d5aec64, // Changing this has security and trust implications.
     .minimum_zig_version = "0.16.0",
     .paths = .{

--- a/src/api/Comptime.zig
+++ b/src/api/Comptime.zig
@@ -20,38 +20,38 @@ pub inline fn print(self: *Chameleon, writer: *std.Io.Writer, comptime text: []c
 }
 
 /// Print the formatted text to a buffered `File` writer.
-pub inline fn printFileBuffered(self: *Chameleon, file: std.fs.File, comptime format: []const u8, args: anytype) !void {
+pub inline fn printFileBuffered(self: *Chameleon, io: std.Io, file: std.Io.File, comptime format: []const u8, args: anytype) !void {
     var buf: [1024]u8 = undefined;
-    var writer = file.writer(&buf);
+    var writer = file.writer(io, &buf);
     try self.print(&writer.interface, format, args);
     try writer.interface.flush();
 }
 
 /// Print the formatted text to buffered stdout.
-pub inline fn printOutBuffered(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
-    return self.printFileBuffered(.stdout(), format, args);
+pub inline fn printOutBuffered(self: *Chameleon, io: std.Io, comptime format: []const u8, args: anytype) !void {
+    return self.printFileBuffered(io, .stdout(), format, args);
 }
 
 /// Print the formatted text to buffered stderr.
-pub inline fn printErrBuffered(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
-    return self.printFileBuffered(.stderr(), format, args);
+pub inline fn printErrBuffered(self: *Chameleon, io: std.Io, comptime format: []const u8, args: anytype) !void {
+    return self.printFileBuffered(io, .stderr(), format, args);
 }
 
 /// Print the formatted text to a `File` writer.
-pub inline fn printFile(self: *Chameleon, file: std.fs.File, comptime format: []const u8, args: anytype) !void {
-    var writer = file.writer(&.{});
+pub inline fn printFile(self: *Chameleon, io: std.Io, file: std.Io.File, comptime format: []const u8, args: anytype) !void {
+    var writer = file.writer(io, &.{});
     try self.print(&writer.interface, format, args);
     try writer.interface.flush();
 }
 
 /// Print the formatted text to stdout.
-pub inline fn printOut(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
-    return self.printFile(.stdout(), format, args);
+pub inline fn printOut(self: *Chameleon, io: std.Io, comptime format: []const u8, args: anytype) !void {
+    return self.printFile(io, .stdout(), format, args);
 }
 
 /// Print the formatted text to stderr.
-pub inline fn printErr(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
-    return self.printFile(.stderr(), format, args);
+pub inline fn printErr(self: *Chameleon, io: std.Io, comptime format: []const u8, args: anytype) !void {
+    return self.printFile(io, .stderr(), format, args);
 }
 
 pub inline fn addStyle(self: *Chameleon, comptime style_name: []const u8) *Chameleon {

--- a/src/api/Runtime.zig
+++ b/src/api/Runtime.zig
@@ -35,38 +35,38 @@ pub fn print(self: *Chameleon, writer: *std.Io.Writer, comptime format: []const 
 }
 
 /// Print the formatted text to a buffered `File` writer.
-pub fn printFileBuffered(self: *Chameleon, file: std.fs.File, comptime format: []const u8, args: anytype) !void {
+pub fn printFileBuffered(self: *Chameleon, io: std.Io, file: std.Io.File, comptime format: []const u8, args: anytype) !void {
     var buf: [1024]u8 = undefined;
-    var writer = file.writer(&buf);
+    var writer = file.writer(io, &buf);
     try self.print(&writer.interface, format, args);
     try writer.interface.flush();
 }
 
 /// Print the formatted text to buffered stdout.
-pub fn printOutBuffered(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
-    return self.printFile(.stdout(), format, args);
+pub fn printOutBuffered(self: *Chameleon, io: std.Io, comptime format: []const u8, args: anytype) !void {
+    return self.printFileBuffered(io, .stdout(), format, args);
 }
 
 /// Print the formatted text to buffered stderr.
-pub fn printErrBuffered(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
-    return self.printFile(.stderr(), format, args);
+pub fn printErrBuffered(self: *Chameleon, io: std.Io, comptime format: []const u8, args: anytype) !void {
+    return self.printFileBuffered(io, .stderr(), format, args);
 }
 
 /// Print the formatted text to a `File` writer.
-pub fn printFile(self: *Chameleon, file: std.fs.File, comptime format: []const u8, args: anytype) !void {
-    var writer = file.writer(&.{});
+pub fn printFile(self: *Chameleon, io: std.Io, file: std.Io.File, comptime format: []const u8, args: anytype) !void {
+    var writer = file.writer(io, &.{});
     try self.print(&writer.interface, format, args);
     try writer.interface.flush();
 }
 
 /// Print the formatted text to stdout.
-pub fn printOut(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
-    return self.printFile(.stdout(), format, args);
+pub fn printOut(self: *Chameleon, io: std.Io, comptime format: []const u8, args: anytype) !void {
+    return self.printFile(io, .stdout(), format, args);
 }
 
 /// Print the formatted text to stderr.
-pub fn printErr(self: *Chameleon, comptime format: []const u8, args: anytype) !void {
-    return self.printFile(.stderr(), format, args);
+pub fn printErr(self: *Chameleon, io: std.Io, comptime format: []const u8, args: anytype) !void {
+    return self.printFile(io, .stderr(), format, args);
 }
 
 pub fn addStyle(self: *Chameleon, comptime style_name: []const u8) *Chameleon {

--- a/src/chameleon.zig
+++ b/src/chameleon.zig
@@ -12,10 +12,27 @@ const Config = struct {
     detect_no_color: bool = true,
 };
 
-pub fn initRuntime(config: Config) RuntimeChameleon {
+pub fn initRuntimeNoDetect(config: Config) RuntimeChameleon {
     return .{
         .allocator = config.allocator,
-        .no_color = if (!config.detect_no_color) false else std.process.hasEnvVarConstant("NO_COLOR"),
+        .no_color = false,
+    };
+}
+
+pub fn initRuntime(config: Config) std.process.Environ.CreateMapError!RuntimeChameleon {
+    if (config.detect_no_color) {
+        var environ_map = try std.process.Environ.createMap(.empty, config.allocator);
+        defer environ_map.deinit();
+        return initRuntimeFromEnviron(config, *environ_map);
+    } else {
+        return initRuntimeNoDetect(config);
+    }
+}
+
+pub fn initRuntimeFromEnviron(config: Config, environ_map: *std.process.Environ.Map) RuntimeChameleon {
+    return .{
+        .allocator = config.allocator,
+        .no_color = if (!config.detect_no_color) false else environ_map.contains("NO_COLOR"),
     };
 }
 

--- a/src/chameleon.zig
+++ b/src/chameleon.zig
@@ -23,13 +23,13 @@ pub fn initRuntime(config: Config) std.process.Environ.CreateMapError!RuntimeCha
     if (config.detect_no_color) {
         var environ_map = try std.process.Environ.createMap(.empty, config.allocator);
         defer environ_map.deinit();
-        return initRuntimeFromEnviron(config, *environ_map);
+        return initRuntimeFromEnviron(config, &environ_map);
     } else {
         return initRuntimeNoDetect(config);
     }
 }
 
-pub fn initRuntimeFromEnviron(config: Config, environ_map: *std.process.Environ.Map) RuntimeChameleon {
+pub fn initRuntimeFromEnviron(config: Config, environ_map: *const std.process.Environ.Map) RuntimeChameleon {
     return .{
         .allocator = config.allocator,
         .no_color = if (!config.detect_no_color) false else environ_map.contains("NO_COLOR"),

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const Chameleon = @import("chameleon");
 
-pub fn main() !void {
+pub fn main(_: std.process.Init) !void {
     comptime var c = Chameleon.initComptime();
     comptime var header = c.underline().bold().italic().blink().createPreset();
     std.debug.print("\n\t\t  {s}{s}{s}{s}{s}{s}{s}{s}{s}\n\n", .{


### PR DESCRIPTION
Many of the Writergate code I fixed for Zig 0.15 had a small change which requires an `io`, which could possibly be wrapped into the Chameleon object moving forward.
My only concern on that point is that `io` is not required if you provide Chameleon with `std.Io.Writer`s rather than trying the more ergonomic `std.Io.File.stdout()`.

The more contentious changes come with the Runtime API initialization methods.
I have tried to be as ergonomic as possible while giving users the option for a fallible and infallible initializer.

- `initRuntime` as we knew it is now fallible, as you need a `*std.process.Environ.Map` to look for the `NO_COLOR` variable
- `initRuntimeNoDetect` is provided as an infallible method when users wish to manually implement color support detection.
- `initRuntimeFromEnviron` is (my personal) recommended method, as it is infallible and retains the `NO_COLOR` detection at the cost of requiring a `*std.process.Environ.Map` (likely from `init.environ_map`) be provided.